### PR TITLE
Fix export of AnalogAccelerometer when used with a PIDSubsystem

### DIFF
--- a/src/main/resources/export/cpp/ExportDescription.yaml
+++ b/src/main/resources/export/cpp/ExportDescription.yaml
@@ -204,6 +204,7 @@ Instructions:
   AnalogAccelerometer:
     Defaults: "AnalogInput,Component,None"
     ClassName: "AnalogAccelerometer"
+    PID: "#variable($Short_Name)->GetAcceleration()"
     Extra: >-
       #variable($Name)->SetSensitivity(${Volts_Per_G});
               #variable($Name)->SetZero(${Zero_G_Volts});

--- a/src/main/resources/export/java/ExportDescription.yaml
+++ b/src/main/resources/export/java/ExportDescription.yaml
@@ -211,6 +211,7 @@ Instructions:
   AnalogAccelerometer:
     Defaults: "AnalogInput,Component,None"
     ClassName: "AnalogAccelerometer"
+    PID: "#variable($Short_Name).getAcceleration()"
     Extra: >-
       #variable($Name).setSensitivity(${Volts_Per_G});
               #variable($Name).setZero(${Zero_G_Volts});


### PR DESCRIPTION
Previously it inherited from AnalogInput and used GetAverageVoltage
which doesn't exist for AnalogAccelerometer. Change to use
GetAcceleration