### PR TITLE
Fix a few instances of frc namespace

### DIFF
--- a/src/main/resources/export/cpp/RobotMap-allocation.cpp
+++ b/src/main/resources/export/cpp/RobotMap-allocation.cpp
@@ -1,5 +1,5 @@
 #foreach ($component in $components)
 #if ($helper.exportsTo("RobotMap", $component))
-std::shared_ptr<frc::#type($component)> RobotMap::#variable($component.fullName);
+std::shared_ptr<#type($component)> RobotMap::#variable($component.fullName);
 #end
 #end

--- a/src/main/resources/export/cpp/Subsystem.h
+++ b/src/main/resources/export/cpp/Subsystem.h
@@ -1,5 +1,5 @@
 #set($subsystem = $helper.getByName($subsystem-name, $robot))
-#macro( klass $cmd )#if( "#type($cmd)" == "" )Subsystem#else#type($cmd)#end#end
+#macro( klass $cmd )#if( "#type($cmd)" == "" )frc::Subsystem#else#type($cmd)#end#end
 #header()
 
 #ifndef #constant($subsystem.name)_H
@@ -12,7 +12,7 @@
  *
  * @author ExampleAuthor
  */
-class #class($subsystem.name): public frc::#klass($subsystem) {
+class #class($subsystem.name): public #klass($subsystem) {
 private:
 	// It's desirable that everything possible is private except
 	// for methods that implement subsystem capabilities


### PR DESCRIPTION
RobotMap Allocations had export had frc::frc::
Subsystems would have been broken for extensions not in frc
namespace.