### PR TITLE
Fix export of Conditional Commands to SmartDashboard

### DIFF
--- a/src/main/resources/PaletteDescription.yaml
+++ b/src/main/resources/PaletteDescription.yaml
@@ -893,6 +893,9 @@ Palette:
           - !Parameters
             name: Parameters
             default: []
+          - !ParameterSet
+            name: Parameter presets
+            default: []
           - !BooleanProperty
             name: Button on SmartDashboard
             default: true


### PR DESCRIPTION
Conditional Commands didn't have a parameter preset field which
caused the OI export to fail.