### PR TITLE
Update classpath with opencv, cscore, and wpiutil

### DIFF
--- a/src/main/resources/export/java/.classpath
+++ b/src/main/resources/export/java/.classpath
@@ -1,7 +1,7 @@
 <classpath>
   <classpathentry kind="src" path="src"/>
   <classpathentry kind="var" path="wpilib" sourcepath="wpilib.sources"/>
-  <classpathentry kind="var" path="networktables" sourcepath="networktables.sources"/>
+  <classpathentry kind="var" path="networktables" sourcepath="ntcore.sources"/>
   <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
   <classpathentry kind="output" path="bin"/>
   <classpathentry kind="var" path="opencv" sourcepath="opencv.sources"/>

--- a/src/main/resources/export/java/.classpath
+++ b/src/main/resources/export/java/.classpath
@@ -4,4 +4,7 @@
   <classpathentry kind="var" path="networktables" sourcepath="networktables.sources"/>
   <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
   <classpathentry kind="output" path="bin"/>
+  <classpathentry kind="var" path="opencv" sourcepath="opencv.sources"/>
+  <classpathentry kind="var" path="cscore" sourcepath="cscore.sources"/>
+  <classpathentry kind="var" path="wpiutil" sourcepath="wpiutil.sources"/>
 </classpath>


### PR DESCRIPTION
This ensures you don't have to close and reopen eclipse before you
can use opencv/cscore.