### PR TITLE
Add New Component type.

### DIFF
--- a/src/main/resources/PaletteDescription.yaml
+++ b/src/main/resources/PaletteDescription.yaml
@@ -269,7 +269,7 @@ Palette:
       - !Component
         name: Subsystem
         type: Subsystem
-        supports: {Sensor: -1, Actuator: -1, Controller: -1, PIDSource: -1, PIDOutput: -1}
+        supports: {Sensor: -1, Actuator: -1, Controller: -1, PIDSource: -1, PIDOutput: -1, PIDCANOutput: -1}
         help: A functional part of your robot that groups the sensors and actuators together.
         properties:
           - !ConstantsProperty
@@ -287,7 +287,7 @@ Palette:
       - !Component
         name: PID Subsystem
         type: Subsystem
-        supports: {Sensor: -1, Actuator: -1, Controller: -1, Pneumatic: -1, PIDSource: -1, PIDOutput: -1}
+        supports: {Sensor: -1, Actuator: -1, Controller: -1, Pneumatic: -1, PIDSource: -1, PIDOutput: -1, PIDCANOutput: -1}
         help: A PID Subsystem is a subsystem that uses a PID control loop.
         properties:
           - !ConstantsProperty
@@ -356,7 +356,7 @@ Palette:
       - !Component
         name: PID Controller
         type: Controller
-        supports: {PIDSource: 1, PIDOutput: 1}
+        supports: {PIDSource: 1, PIDOutput: 1, PIDCANOutput: 1}
         help: PID controllers allow control of an actuator based off of feedback from a sensor.
         properties:
           - !ChildSelectionProperty
@@ -414,7 +414,7 @@ Palette:
       - !Component
         name: Robot Drive 2
         type: Controller
-        supports: {PIDOutput: 2}
+        supports: {PIDOutput: 2, PIDCANOutput: 2}
         help: RobotDrive handles tank, arcade, holonomic and mecanum drive.
         properties:
           - !ChildSelectionProperty
@@ -448,7 +448,7 @@ Palette:
       - !Component
         name: Robot Drive 4
         type: Controller
-        supports: {PIDOutput: 4}
+        supports: {PIDOutput: 4, PIDCANOutput: 4}
         help: RobotDrive handles tank, arcade, holonomic and mecanum drive.
         properties:
           - !ChildSelectionProperty
@@ -498,7 +498,7 @@ Palette:
       - !Component
         name: Speed Controller Group
         type: PIDOutput
-        supports: {PIDOutput: 4}
+        supports: {PIDOutput: 4, PIDCANOutput: 4}
         help: Speed Controller Group handles multiple speed controllers as one
         properties:
           - !ChildSelectionProperty
@@ -522,7 +522,7 @@ Palette:
       - !Component
         name: Differential Drive
         type: Controller
-        supports: {PIDOutput: 2}
+        supports: {PIDOutput: 2, PIDCANOutput: 2}
         help: RobotDrive handles tank and arcade drives
         properties:
           - !ChildSelectionProperty
@@ -547,7 +547,7 @@ Palette:
       - !Component
         name: Mecanum Drive
         type: Controller
-        supports: {PIDOutput: 4}
+        supports: {PIDOutput: 4, PIDCANOutput: 4}
         help: Controller for Mecanum Drive Trains
         properties:
           - !ChildSelectionProperty
@@ -582,7 +582,7 @@ Palette:
       - !Component
         name: Killough Drive
         type: Controller
-        supports: {PIDOutput: 3}
+        supports: {PIDOutput: 3, PIDCANOutput: 3}
         help: RobotDrive handles tank and arcade drives
         properties:
           - !ChildSelectionProperty

--- a/src/main/resources/export/java/ExportDescription.yaml
+++ b/src/main/resources/export/java/ExportDescription.yaml
@@ -91,27 +91,27 @@ Defaults:
     ClassName: ""
   AnalogInput:
     Construction: "#variable($Short_Name) = new ${ClassName}(${Input_Channel_Analog});"
-    LiveWindow: "addChild(#variable($Short_Name));"
+    LiveWindow: "addChild(\"$Short_Name\",#variable($Short_Name));"
     PID: "#variable($Short_Name).getAverageVoltage()"
   AnalogPotentiometer:
     Construction: "#variable($Short_Name) = new ${ClassName}(${Input_Channel_Analog}, ${Full_Range}, ${Offset});"
-    LiveWindow: "addChild(#variable($Short_Name));"
+    LiveWindow: "addChild(\"$Short_Name\",#variable($Short_Name));"
     PID: "#variable($Short_Name).get()"
   DigitalInput:
     Construction: "#variable($Short_Name) = new ${ClassName}(${Input_Channel_Digital});"
-    LiveWindow: "addChild(#variable($Short_Name));"
+    LiveWindow: "addChild(\"$Short_Name\",#variable($Short_Name));"
   PWMOutput:
     Construction: "#variable($Short_Name) = new ${ClassName}(${Output_Channel_PWM});"
-    LiveWindow: "addChild(#variable($Short_Name));"
+    LiveWindow: "addChild(\"$Short_Name\",#variable($Short_Name));"
   RelayOutput:
     Construction: "#variable($Short_Name) = new ${ClassName}(${Output_Channel_Relay});"
-    LiveWindow: "addChild(#variable($Short_Name));"
+    LiveWindow: "addChild(\"$Short_Name\",#variable($Short_Name));"
   SolenoidOutput:
     Construction: "#variable($Short_Name) = new ${ClassName}(${Output_PCM_Solenoid}, ${Output_Channel_Solenoid});"
-    LiveWindow: "addChild(#variable($Short_Name));"
+    LiveWindow: "addChild(\"$Short_Name\",#variable($Short_Name));"
   AnalogOutput:
     Construction: "#variable($Short_Name) = new ${ClassName}(${Output_Channel_AnalogOutput});"
-    LiveWindow: "addChild(#variable($Short_Name));"
+    LiveWindow: "addChild(\"$Short_Name\",#variable($Short_Name));"
   OI:
     Export: "OI"
     Import: "import edu.wpi.first.wpilibj.${ClassName};\nimport ${package}.subsystems.*;"
@@ -164,7 +164,7 @@ Instructions:
 
               SmartDashboard.putData("${Name}", #variable($Short_Name));#end
 
-    LiveWindow: "addChild(#variable($Short_Name));"
+    LiveWindow: "addChild(\"$Short_Name\",#variable($Short_Name));"
 
   Robot Drive 2:
     Defaults: "Component,None"
@@ -210,13 +210,13 @@ Instructions:
     Construction: >-
       #variable($Short_Name) = new ${ClassName}(#variable($SpeedController1), #variable($SpeedController2)
       #if(($SpeedController3)), #variable($SpeedController3)#end #if(($SpeedController4)), #variable($SpeedController4)#end);
-    LiveWindow: "addChild(#variable($Short_Name));"
+    LiveWindow: "addChild(\"$Short_Name\",#variable($Short_Name));"
   Differential Drive:
     Defaults: "Component,None"
     ClassName: "DifferentialDrive"
     Import: "import edu.wpi.first.wpilibj.drive.DifferentialDrive;"
     Construction: "#variable($Short_Name) = new ${ClassName}(#variable($Left_Motor), #variable($Right_Motor));"
-    LiveWindow: "addChild(#variable($Short_Name));"
+    LiveWindow: "addChild(\"$Short_Name\",#variable($Short_Name));"
     Extra: >
       #variable($Short_Name).setSafetyEnabled($Safety_Enabled);
               #variable($Short_Name).setExpiration($Safety_Expiration_Time);
@@ -225,7 +225,7 @@ Instructions:
     Defaults: "Component,None"
     ClassName: "MecanumDrive"
     Import: "import edu.wpi.first.wpilibj.drive.MecanumDrive;"
-    LiveWindow: "addChild(#variable($Short_Name));"
+    LiveWindow: "addChild(\"$Short_Name\",#variable($Short_Name));"
     Construction: >-
       #variable($Short_Name) = new ${ClassName}(#variable($Left_Front_Motor), #variable($Left_Rear_Motor),
                     #variable($Right_Front_Motor), #variable($Right_Rear_Motor));
@@ -237,7 +237,7 @@ Instructions:
     Defaults: "Component,None"
     ClassName: "KilloughDrive"
     Import: "import edu.wpi.first.wpilibj.drive.KilloughDrive;"
-    LiveWindow: "addChild(#variable($Short_Name));"
+    LiveWindow: "addChild(\"$Short_Name\",#variable($Short_Name));"
     Construction: >-
       #variable($Short_Name) = new ${ClassName}(#variable($Left_Motor), #variable($Right_Motor),
                      #variable($Back_Motor));
@@ -251,12 +251,12 @@ Instructions:
     ClassName: "AnalogGyro"
     Extra: "#variable($Short_Name).setSensitivity(${Sensitivity});"
     PID: "#variable($Short_Name).pidGet()"
-    LiveWindow: "addChild(#variable($Short_Name));"
+    LiveWindow: "addChild(\"$Short_Name\",#variable($Short_Name));"
   AnalogAccelerometer:
     Defaults: "AnalogInput,Component,None"
     ClassName: "AnalogAccelerometer"
     PID: "#variable($Short_Name).getAcceleration()"
-    LiveWindow: "addChild(#variable($Short_Name));"
+    LiveWindow: "addChild(\"$Short_Name\",#variable($Short_Name));"
     Extra: >-
       #variable($Short_Name).setSensitivity(${Volts_Per_G});
               #variable($Short_Name).setZero(${Zero_G_Volts});
@@ -265,7 +265,7 @@ Instructions:
     ClassName: "Encoder"
     Import: "import edu.wpi.first.wpilibj.Encoder;\nimport edu.wpi.first.wpilibj.CounterBase.EncodingType;\nimport edu.wpi.first.wpilibj.PIDSourceType;"
     Construction: "#variable($Short_Name) = new ${ClassName}(${Channel_A_Channel_Digital}, ${Channel_B_Channel_Digital}, ${Reverse_Direction}, EncodingType.${Encoding_Type});"
-    LiveWindow: "addChild(#variable($Short_Name));"
+    LiveWindow: "addChild(\"$Short_Name\",#variable($Short_Name));"
     Extra: >-
       #variable($Short_Name).setDistancePerPulse(${Distance_Per_Pulse});
               #variable($Short_Name).setPIDSourceType(PIDSourceType.${PID_Source});
@@ -275,7 +275,7 @@ Instructions:
     Construction: "#variable($Name) = new ${ClassName}(${Channel_A_Channel_Digital}, ${Channel_B_Channel_Digital}, ${Reverse_Direction});"
     Import: "import edu.wpi.first.wpilibj.Encoder;\nimport edu.wpi.first.wpilibj.CounterBase.EncodingType;\nimport edu.wpi.first.wpilibj.PIDSourceType;\nimport edu.wpi.first.wpilibj.Encoder.IndexingType;"
     Construction: "#variable($Short_Name) = new ${ClassName}(${Channel_A_Channel_Digital}, ${Channel_B_Channel_Digital}, ${Reverse_Direction});"
-    LiveWindow: "addChild(#variable($Short_Name));"
+    LiveWindow: "addChild(\"$Short_Name\",#variable($Short_Name));"
     Extra: >-
       #variable($Short_Name).setDistancePerPulse(${Distance_Per_Pulse});
               #variable($Short_Name).setPIDSourceType(PIDSourceType.${PID_Source});
@@ -304,7 +304,7 @@ Instructions:
     Defaults: "Component,None"
     ClassName: "PowerDistributionPanel"
     Construction: "#variable($Short_Name) = new ${ClassName}($CAN_ID);"
-    LiveWindow: "addChild(#variable($Short_Name));"
+    LiveWindow: "addChild(\"$Short_Name\",#variable($Short_Name));"
 
   Speed Controller:
     Defaults: "PWMOutput,Component,None"
@@ -312,14 +312,14 @@ Instructions:
     Import: "import edu.wpi.first.wpilibj.${Type};\nimport edu.wpi.first.wpilibj.${ClassName};"
     Declaration: "private ${Type} #variable($Short_Name);"
     Construction: "#variable($Short_Name) = new ${Type}(${Output_Channel_PWM});"
-    LiveWindow: "addChild(#variable($Short_Name));"
+    LiveWindow: "addChild(\"$Short_Name\",#variable($Short_Name));"
     Extra: >-
       #variable($Short_Name).setInverted(${Inverted});
   Nidec Brushless:
     Defaults: "Component,None"
     ClassName: "NidecBrushless"
     Construction: "#variable($Short_Name) = new ${ClassName}(${Output_Channel_PWM}, ${Output_Channel_Digital});"
-    LiveWindow: "addChild(#variable($Short_Name));"
+    LiveWindow: "addChild(\"$Short_Name\",#variable($Short_Name));"
     Extra: >-
       #variable($Short_Name).setInverted(${Inverted});
   Servo:
@@ -329,7 +329,7 @@ Instructions:
     Defaults: "Component,None"
     ClassName: "DigitalOutput"
     Construction: "#variable($Short_Name) = new ${ClassName}(${Output_Channel_Digital});"
-    LiveWindow: "addChild(#variable($Short_Name));"
+    LiveWindow: "addChild(\"$Short_Name\",#variable($Short_Name));"
   Spike:
     Defaults: "RelayOutput,Component,None"
     ClassName: "Relay"
@@ -341,7 +341,7 @@ Instructions:
     Defaults: "Component,None"
     ClassName: "Compressor"
     Construction: "#variable($Short_Name) = new ${ClassName}(${PCM_ID});"
-    LiveWindow: "addChild(#variable($Short_Name));"
+    LiveWindow: "addChild(\"$Short_Name\",#variable($Short_Name));"
   Solenoid:
     Defaults: "SolenoidOutput,Component,None"
     ClassName: "Solenoid"
@@ -357,7 +357,7 @@ Instructions:
       #end##
 
       #variable($Short_Name) = new ${ClassName}(${Forward_PCM_Solenoid}, ${Forward_Channel_Solenoid}, ${Reverse_Channel_Solenoid});
-    LiveWindow: "addChild(#variable($Short_Name));"
+    LiveWindow: "addChild(\"$Short_Name\",#variable($Short_Name));"
 
   Joystick:
     Defaults: "OI,None"

--- a/src/main/resources/export/java/Subsystem-constructors.java
+++ b/src/main/resources/export/java/Subsystem-constructors.java
@@ -6,5 +6,6 @@
 
         #extra($component)
 
+        
 #end
 #end


### PR DESCRIPTION
I have been working on improving the TalonSRX and VictorSPX add-on extensions for robot builder. Also seeing more CAN enabled devices each year this could be an advantage to isolate these in the context menus when adding components to our Robotbuilder projects.  For now I have been creating a CANSpeedControllerGroup to leverage the follow features.  Jacob from CTRE said he will work on posting their extensions publicly so the community can submit Pull Request to help improve the functionality of their add-on's. Adding this type will not break the CTRE extensions in its current state only new profiles that would require PIDCANOutput devices and even then the context menues would not have any valid objects to add.. 

As a final note when things level off on development of the other tools in the suite. Maybe a file in the root of the extensions folder to parse custom types to components would be helpful.
A first look might look like this?
**ComponentTypes.yaml**
`Command: {}
Subsystem: {}
PIDOutput: {PIDCANOutput: ($quantity)}
PIDSource: {}
Sensor: {}
Controller: {}
Actuator: {}
Joystick: {}
Joystick Button: {}`

Then ($quantity) would copy the value hard coded already for the components that support the PIDOutput
