### PR TITLE
Exclude RobotBuilder backup files from VSCode File Explorer

### DIFF
--- a/src/main/resources/export/cpp/settings.json
+++ b/src/main/resources/export/cpp/settings.json
@@ -9,7 +9,8 @@
     "**/.DS_Store": true,
     "bin/": true,
     ".classpath": true,
-    ".project": true
+    ".project": true,
+    "**/*~": true
   },
   "C_Cpp.default.configurationProvider": "vscode-wpilib",
   "wpilib.online": true

--- a/src/main/resources/export/java/settings.json
+++ b/src/main/resources/export/java/settings.json
@@ -8,7 +8,8 @@
     "**/.DS_Store": true,
     "bin/": true,
     ".classpath": true,
-    ".project": true
+    ".project": true,
+    "**/*~": true
   },
   "wpilib.online": true
 }


### PR DESCRIPTION
RobotBuilder backups have a ~ at the end, exclude '**/*~'