### PR TITLE
Move test-resources folder to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ save*.yaml
 dependency-reduced-pom.xml
 nbactions.xml
 src/main/resources/export/vendordeps/
+/test/
 
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,12 +5,12 @@
 save*.yaml
 *~
 *#
-/test-resources/RobotBuilderTestProject/*
+/test-resources/
 /.svn/*
 *.exec
 dependency-reduced-pom.xml
 nbactions.xml
-
+src/main/resources/export/vendordeps/
 
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id 'edu.wpi.first.wpilib.repositories.WPILibRepositoriesPlugin' version '2020.1'
     id 'io.franzbecker.gradle-lombok' version '3.1.0'
     id "com.github.johnrengelman.shadow" version "5.1.0"
-    id "de.undercouch.download" version "4.0.1"
+    id "de.undercouch.download" version "4.1.1"
     id 'org.aim42.htmlSanityCheck' version '1.1.3'
 }
 
@@ -70,7 +70,7 @@ jacocoTestReport {
 
 def downloadNewCommands = tasks.register('downloadNewCommands', Download) {
   src 'https://raw.githubusercontent.com/wpilibsuite/allwpilib/master/wpilibNewCommands/WPILibNewCommands.json'
-  dest 'src/main/resources/export/vendordeps/WPILibNewCommands.json'
+  dest 'build/resources/main/export/vendordeps/WPILibNewCommands.json'
   overwrite true
 }
 

--- a/src/test/java/robotbuilder/SavingAndLoadingTest.java
+++ b/src/test/java/robotbuilder/SavingAndLoadingTest.java
@@ -18,6 +18,8 @@ import static org.junit.Assert.assertTrue;
  */
 public class SavingAndLoadingTest {
 
+    private static final String SAVE_FILE = "build/test-resources/save.yml";
+
     public SavingAndLoadingTest() {
     }
 
@@ -44,8 +46,8 @@ public class SavingAndLoadingTest {
         RobotTree tree = TestUtils.getNewRobotTree();
         tree.isRobotValid();
         RobotComponent before = tree.getRoot();
-        tree.save("test/save.yml");
-        tree.load(new File("test/save.yml"));
+        tree.save(SAVE_FILE);
+        tree.load(new File(SAVE_FILE));
         RobotComponent after = tree.getRoot();
         assertEquals("Loaded file should be identical to the saved file.",
                 before, after);
@@ -56,8 +58,8 @@ public class SavingAndLoadingTest {
         RobotTree tree = TestUtils.generateTestTree();
         tree.isRobotValid();
         RobotComponent before = tree.getRoot();
-        tree.save("test/save.yml");
-        tree.load(new File("test/save.yml"));
+        tree.save(SAVE_FILE);
+        tree.load(new File(SAVE_FILE));
         RobotComponent after = tree.getRoot();
         assertEquals("Loaded file should be identical to the saved file.",
                 before, after);

--- a/src/test/java/robotbuilder/TestUtils.java
+++ b/src/test/java/robotbuilder/TestUtils.java
@@ -144,7 +144,7 @@ public class TestUtils {
 
         //enable desktop builds and disable roboRIO builds to allow compile test with desktop compiler.
         try {
-            Path path = Paths.get("test-resources", projectDirectory, "build.gradle");
+            Path path = Paths.get("build/test-resources", projectDirectory, "build.gradle");
             Stream<String> lines = Files.lines(path);
             List<String> replaced = lines
                     .map(line -> line.replaceAll("def includeDesktopSupport = false", "def includeDesktopSupport = true"))
@@ -158,11 +158,11 @@ public class TestUtils {
         boolean isWindows = System.getProperty("os.name").toLowerCase().startsWith("win");
         if (isWindows) {
             System.out.println("Trying Windows compile...");
-            pb = new ProcessBuilder("gradlew.bat", "build", "-Ptoolchain-optional-roboRio").directory(new File("test-resources/" + projectDirectory));
+            pb = new ProcessBuilder("gradlew.bat", "build", "-Ptoolchain-optional-roboRio").directory(new File("build/test-resources/" + projectDirectory));
         } else {
             System.out.println("Trying *NIX compile...");
             //string array necessary to pass build as a parameter to gradle and not sh. https://stackoverflow.com/a/55164823
-            pb = new ProcessBuilder(new String[]{"sh", "-c", "./gradlew build -Ptoolchain-optional-roboRio"}).directory(new File("test-resources/" + projectDirectory));
+            pb = new ProcessBuilder(new String[]{"sh", "-c", "./gradlew build -Ptoolchain-optional-roboRio"}).directory(new File("build/test-resources/" + projectDirectory));
         }
         pb.redirectErrorStream(true);
         System.out.println("Running command: " + Arrays.toString(pb.command().toArray()));

--- a/src/test/java/robotbuilder/exporters/CppExportTest.java
+++ b/src/test/java/robotbuilder/exporters/CppExportTest.java
@@ -35,7 +35,7 @@ public class CppExportTest {
 
     @Before
     public void setUp() {
-        File project = new File("test-resources/" + PROJECT_DIRECTORY);
+        File project = new File("build/test-resources/" + PROJECT_DIRECTORY);
         TestUtils.delete(project);
         assertFalse(project.exists());
         project.mkdir();
@@ -49,7 +49,7 @@ public class CppExportTest {
     public void testCPPExport() throws IOException, InterruptedException {
         RobotTree tree = TestUtils.generateTestTree();
         tree.getRoot().setName(PROJECT_DIRECTORY);
-        tree.getRoot().getProperty("Export Directory").setValueAndUpdate(new File("test-resources/").getAbsolutePath());
+        tree.getRoot().getProperty("Export Directory").setValueAndUpdate(new File("build/test-resources/").getAbsolutePath());
         tree.walk(new RobotWalker() {
             @Override
             public void handleRobotComponent(RobotComponent self) { // Gives us better diagnostics when the robot tree isn't valid.

--- a/src/test/java/robotbuilder/exporters/JavaExportTest.java
+++ b/src/test/java/robotbuilder/exporters/JavaExportTest.java
@@ -37,7 +37,7 @@ public class JavaExportTest {
 
     @Before
     public void setUp() {
-        File project = new File("test-resources/" + PROJECT_DIRECTORY);
+        File project = new File("build/test-resources/" + PROJECT_DIRECTORY);
         TestUtils.delete(project);
         assertFalse(project.exists());
         project.mkdir();
@@ -51,7 +51,7 @@ public class JavaExportTest {
     public void testJavaExport() throws IOException, InterruptedException {
         RobotTree tree = TestUtils.generateTestTree();
         tree.getRoot().setName(PROJECT_DIRECTORY);
-        tree.getRoot().getProperty("Export Directory").setValueAndUpdate(new File("test-resources/").getAbsolutePath());
+        tree.getRoot().getProperty("Export Directory").setValueAndUpdate(new File("build/test-resources/").getAbsolutePath());
         tree.getRoot().getProperty("Java Package").setValueAndUpdate("robotcode");
         tree.walk(new RobotWalker() {
             @Override


### PR DESCRIPTION
Fixes #252
Also fully excludes test-resources in .gitignore for existing files
excludes vendordeps generated folder