### PR TITLE
Populate File Save Name

### DIFF
--- a/src/main/java/robotbuilder/robottree/RobotTree.java
+++ b/src/main/java/robotbuilder/robottree/RobotTree.java
@@ -309,6 +309,7 @@ public class RobotTree extends JPanel {
     }
 
     public void save() {
+        fileChooser.setSelectedFile(new File(treeModel.getRoot().toString()));
         if (getFilePath() == null) {
             int result = fileChooser.showSaveDialog(MainFrame.getInstance());
             if (result == JFileChooser.CANCEL_OPTION) {


### PR DESCRIPTION
One of my annoyances while using robot builder is even though I named my project at the start of a new project I have to retype the name on the first save. This should fix that. 