### PR TITLE
Fix export of C++ extensions

### DIFF
--- a/src/main/resources/export/cpp/ExportDescription.yaml
+++ b/src/main/resources/export/cpp/ExportDescription.yaml
@@ -107,7 +107,6 @@ Defaults:
     LiveWindow: "AddChild(\"$Short_Name\", &m_#variable($Name));"
   OI:
     Export: "OI"
-    Declaration: "std::shared_ptr<frc::${ClassName}> #variable($Name);"
   Button:
     Extra:  "#if(\"$Command\" != \"None\")#variable($Name)->${When_to_Run.substring(0,1).toUpperCase()}${When_to_Run.substring(1)}(#command_instantiation($Command $Parameters));#end"
   Command:
@@ -127,14 +126,11 @@ Instructions:
     Defaults: "None"
     Export: "RobotContainer"
     Import: "\\#include \"subsystems/#class($Short_Name).h\""
-    Declaration: "static std::shared_ptr<#class($Short_Name)> #variable($Short_Name);"
-    Construction: ""
     ClassName: "frc2::SubsystemBase"
   PID Subsystem:
     Defaults: "None"
     Export: "RobotContainer"
     Import: "\\#include \"subsystems/#class($Short_Name).h\""
-    Declaration: "static std::shared_ptr<#class($Short_Name)> #variable($Short_Name);"
     ClassName: "frc2::PIDSubsystem"
 
   PID Controller:

--- a/src/main/resources/export/cpp/ExportDescription.yaml
+++ b/src/main/resources/export/cpp/ExportDescription.yaml
@@ -38,8 +38,9 @@
 ##     - Import: The C++ include so that this component is properly
 ##           included in the generated C++ file
 ##     - Declaration: The declaration to declare a variable
-##           representing this component.
-##     - Construction: The constructor to create this component.
+##           representing this component in the header.
+##     - Construction: The constructor to create this component in the cpp
+##           file.
 ##     - LiveWindow: Put this component on the livewindow properly.
 ##     - Extra: Extra configuration for after the constructor is done.
 ##     - ClassName: The C++ class name of this object.
@@ -70,12 +71,10 @@ Defaults:
     Export: "RobotMap"
     Declaration: "frc::${ClassName}* m_#variable($Name);"
     Import: "\\#include <frc/${ClassName}.h>"
-    Construction: " "
   CustomComponent:
     Export: "RobotMap"
     Import: "\\#include \"Custom/${ClassName}.h\""
-    Declaration: "${ClassName} m_#variable($Name);"
-    Construction: " "
+    Declaration: "std::shared_ptr<${ClassName}> #variable($Name);"
   None:
     Export: ""
     Import: ""
@@ -88,30 +87,23 @@ Defaults:
     PID: "#variable($Short_Name).PIDGet()"
     ClassName: ""
   AnalogInput:
-    Construction: " " #"#variable($Name).reset(new frc::${ClassName}(${Input_Channel_Analog}));"
     Declaration: "frc::${ClassName} m_#variable($Name){${Input_Channel_Analog}};"
     LiveWindow: "AddChild(\"$Short_Name\", &m_#variable($Name));"
     PID: "#variable($Short_Name).GetAverageVoltage()"
   AnalogPotentiometer:
-    Construction: " " #"#variable($Name).reset(new frc::${ClassName}(${Input_Channel_Analog}, ${Full_Range}, ${Offset}));"
     Declaration: "frc::${ClassName} m_#variable($Name){${Input_Channel_Analog}, ${Full_Range}, ${Offset}};"
     LiveWindow: "AddChild(\"$Short_Name\", &m_#variable($Name));"
     PID: "#variable($Short_Name).Get()"
   DigitalInput:
-    Construction: " " #"#variable($Name).reset(new frc::${ClassName}(${Input_Channel_Digital}));"
     Declaration: "frc::${ClassName} m_#variable($Name){${Input_Channel_Digital}};"
     LiveWindow: "AddChild(\"$Short_Name\", &m_#variable($Name));"
   PWMOutput:
-    Construction: " " #"#variable($Name).reset(new frc::${ClassName}(${Output_Channel_PWM}));"
     LiveWindow: "AddChild(\"$Short_Name\", &m_#variable($Name));"
   RelayOutput:
-    Construction: " " #"#variable($Name).reset(new frc::${ClassName}(${Output_Channel_Relay}));"
     LiveWindow: "AddChild(\"$Short_Name\", &m_#variable($Name));"
   AnalogOutput:
-    Construction: " " #"#variable($Name).reset(new frc::${ClassName}(${Output_Channel_AnalogOutput}));"
     LiveWindow: "AddChild(\"$Short_Name\", &m_#variable($Name));"
   SolenoidOutput:
-    Construction: " " #"#variable($Name).reset(new frc::${ClassName}(${Output_PCM_Solenoid}, ${Output_Channel_Solenoid}));"
     LiveWindow: "AddChild(\"$Short_Name\", &m_#variable($Name));"
   OI:
     Export: "OI"
@@ -136,14 +128,13 @@ Instructions:
     Export: "RobotContainer"
     Import: "\\#include \"subsystems/#class($Short_Name).h\""
     Declaration: "static std::shared_ptr<#class($Short_Name)> #variable($Short_Name);"
-    Construction: "#variable($Short_Name).reset(new #class($Short_Name)());"
+    Construction: ""
     ClassName: "frc2::SubsystemBase"
   PID Subsystem:
     Defaults: "None"
     Export: "RobotContainer"
     Import: "\\#include \"subsystems/#class($Short_Name).h\""
     Declaration: "static std::shared_ptr<#class($Short_Name)> #variable($Short_Name);"
-    Construction: "" ##"#variable($Short_Name).reset(new #class($Short_Name)());"
     ClassName: "frc2::PIDSubsystem"
 
   PID Controller:
@@ -166,7 +157,6 @@ Instructions:
     Defaults: "Component,None"
     ClassName: "RobotDrive"
     Declaration: "frc::${ClassName} m_#variable($Name){m_#variable($Left_Motor), m_#variable($Right_Motor)};"
-    Construction: "#variable($Name).reset(new frc::${ClassName}(#variable($Left_Motor), #variable($Right_Motor)));"
     Extra: >
       m_#variable($Name).SetSafetyEnabled($Safety_Enabled);
               m_#variable($Name).SetExpiration($Safety_Expiration_Time);
@@ -183,9 +173,6 @@ Instructions:
     ClassName: "RobotDrive"
     Declaration: "frc::${ClassName} m_#variable($Name){m_#variable($Left_Front_Motor), m_#variable($Left_Rear_Motor),
                     m_#variable($Right_Front_Motor), m_#variable($Right_Rear_Motor)};"
-    Construction: >-
-      #variable($Name).reset(new frc::${ClassName}(#variable($Left_Front_Motor), #variable($Left_Rear_Motor),
-                    #variable($Right_Front_Motor), #variable($Right_Rear_Motor)));
     Extra: >
       m_#variable($Name).SetSafetyEnabled($Safety_Enabled);
               m_#variable($Name).SetExpiration($Safety_Expiration_Time);
@@ -209,14 +196,10 @@ Instructions:
     Declaration: "frc::${ClassName} m_#variable($Name){m_#variable($SpeedController1), m_#variable($SpeedController2)
       #if(($SpeedController3)), m_#variable($SpeedController3)#end #if(($SpeedController4)), m_#variable($SpeedController4)#end};"
     LiveWindow: "AddChild(\"$Short_Name\", &m_#variable($Name));"
-    Construction: >-
-      #variable($Name) = std::make_shared<frc::${ClassName}>(*#variable($SpeedController1), *#variable($SpeedController2)
-      #if(($SpeedController3)), *#variable($SpeedController3)#end #if(($SpeedController4)), *#variable($SpeedController4)#end);
   Differential Drive:
     Defaults: "Component,None"
     ClassName: "DifferentialDrive"
     Declaration: "frc::${ClassName} m_#variable($Name){m_#variable($Left_Motor), m_#variable($Right_Motor)};"
-    Construction: "#variable($Name).reset(new frc::${ClassName}(*#variable($Left_Motor), *#variable($Right_Motor)));"
     LiveWindow: "AddChild(\"$Short_Name\", &m_#variable($Name));"
     Import: "\\#include <frc/drive/${ClassName}.h>"
     Extra: >
@@ -230,9 +213,6 @@ Instructions:
                     m_#variable($Right_Front_Motor), m_#variable($Right_Rear_Motor)};"
     LiveWindow: "AddChild(\"$Short_Name\", &m_#variable($Name));"
     Import: "\\#include <frc/drive/${ClassName}.h>"
-    Construction: >-
-      #variable($Name).reset(new frc::${ClassName}(*#variable($Left_Front_Motor), *#variable($Left_Rear_Motor),
-                    *#variable($Right_Front_Motor), *#variable($Right_Rear_Motor)));
     Extra: >
       m_#variable($Name).SetSafetyEnabled($Safety_Enabled);
               m_#variable($Name).SetExpiration($Safety_Expiration_Time);
@@ -244,9 +224,6 @@ Instructions:
                     m_#variable($Back_Motor)};"
     LiveWindow: "AddChild(\"$Short_Name\", &m_#variable($Name));"
     Import: "\\#include <frc/drive/${ClassName}.h>"
-    Construction: >-
-      #variable($Name).reset(new frc::${ClassName}(*#variable($Left_Motor), *#variable($Right_Motor),
-                    *#variable($Back_Motor)));
     Extra: >
       m_#variable($Name).SetSafetyEnabled($Safety_Enabled);
               m_#variable($Name).SetExpiration($Safety_Expiration_Time);
@@ -270,7 +247,6 @@ Instructions:
     Defaults: "DigitalInput,Component,None"
     ClassName: "Encoder"
     Declaration: "frc::Encoder m_#variable($Name){${Channel_A_Channel_Digital}, ${Channel_B_Channel_Digital}, ${Reverse_Direction}, frc::Encoder::${Encoding_Type}};"
-    Construction: "" #"#variable($Name).reset(new frc::${ClassName}(${Channel_A_Channel_Digital}, ${Channel_B_Channel_Digital}, ${Reverse_Direction}, frc::Encoder::${Encoding_Type}));"
     Extra: >-
       m_#variable($Name).SetDistancePerPulse(${Distance_Per_Pulse});
           m_#variable($Name).SetPIDSourceType(frc::PIDSourceType::${PID_Source});
@@ -278,7 +254,6 @@ Instructions:
     Defaults: "DigitalInput,Component,None"
     ClassName: "Encoder"
     Declaration: "frc::Encoder m_#variable($Name){${Channel_A_Channel_Digital}, ${Channel_B_Channel_Digital}, ${Reverse_Direction}};"
-    Construction: "" #"#variable($Name).reset(new frc::${ClassName}(${Channel_A_Channel_Digital}, ${Channel_B_Channel_Digital}, ${Reverse_Direction}));"
     Extra: >-
       m_#variable($Name).SetDistancePerPulse(${Distance_Per_Pulse});
           m_#variable($Name).SetPIDSourceType(frc::PIDSourceType::${PID_Source});
@@ -287,7 +262,6 @@ Instructions:
     Defaults: "DigitalInput,Component,None"
     ClassName: "GearTooth"
     Declaration: "frc::GearTooth m_#variable($Name){${Input_Channel_Digital}, ${Direction_Sensitive}};"
-    Construction: "#variable($Name).reset(new frc::${ClassName}(${Input_Channel_Digital}, ${Direction_Sensitive}));"
   Analog Potentiometer:
     Defaults: "AnalogPotentiometer,Component,None"
     ClassName: "AnalogPotentiometer"
@@ -304,26 +278,22 @@ Instructions:
     Defaults: "DigitalInput,Component,None"
     ClassName: "Ultrasonic"
     Declaration: "frc::Ultrasonic m_#variable($Name){${Ping_Channel_Digital}, ${Echo_Channel_Digital}};"
-    Construction: "" #"#variable($Name).reset(new frc::${ClassName}(${Ping_Channel_Digital}, ${Echo_Channel_Digital}));"
   PowerDistributionPanel:
     Defaults: "Component,None"
     ClassName: "PowerDistributionPanel"
     Declaration: "frc::PowerDistributionPanel m_#variable($Name){$CAN_ID};"
-    Construction: "" #"#variable($Name).reset(new frc::${ClassName}($CAN_ID));"
     LiveWindow: "AddChild(\"$Short_Name\", &m_#variable($Name));"
 
   Speed Controller:
     Defaults: "PWMOutput,Component,None"
     ClassName: "SpeedController"
     Declaration: "frc::${Type} m_#variable($Name){${Output_Channel_PWM}};"
-    Construction: " " #"#variable($Name).reset(new frc::${Type}(${Output_Channel_PWM}));"
     LiveWindow: "AddChild(\"$Short_Name\", &m_#variable($Name));"
     Import: "\\#include <frc/${Type}.h>"
   Nidec Brushless:
     Defaults: "Component,None"
     ClassName: "NidecBrushless"
     Declaration: "frc::${ClassName} m_#variable($Name){${Output_Channel_PWM}, ${Output_Channel_Digital}};"
-    Construction: " " #"#variable($Name).reset(new frc::${ClassName}(${Output_Channel_PWM}, ${Output_Channel_Digital}));"
     LiveWindow: "AddChild(\"$Short_Name\", &m_#variable($Name));"
   Servo:
     Defaults: "PWMOutput,Component,None"
@@ -333,7 +303,6 @@ Instructions:
     Defaults: "Component,None"
     ClassName: "DigitalOutput"
     Declaration: "frc::${ClassName} m_#variable($Name){${Output_Channel_Digital}};"
-    Construction: " " #"#variable($Name).reset(new frc::${ClassName}(${Output_Channel_Digital}));"
     LiveWindow: "AddChild(\"$Short_Name\", &m_#variable($Name));"
   Spike:
     Defaults: "RelayOutput,Component,None"
@@ -348,7 +317,6 @@ Instructions:
     Defaults: "Component,None"
     ClassName: "Compressor"
     Declaration: "frc::Compressor m_#variable($Name){${PCM_ID}};"
-    Construction: "" # "#variable($Name).reset(new frc::${ClassName}(${PCM_ID}));"
     LiveWindow: "AddChild(\"$Short_Name\", &m_#variable($Name));"
   Solenoid:
     Defaults: "SolenoidOutput,Component,None"
@@ -362,12 +330,6 @@ Instructions:
   Double Solenoid:
     Defaults: "Solenoid,Component,None"
     ClassName: "DoubleSolenoid"
-    Construction: >-
-      #if(${Forward_PCM_Solenoid} != ${Reverse_PCM_Solenoid})Warning, the two modules in robot builder are different!
-
-      #end##
-            # #variable($Name).reset(new frc::${ClassName}(${Forward_PCM_Solenoid}, ${Forward_Channel_Solenoid}, ${Reverse_Channel_Solenoid}));
-
     Declaration: "frc::DoubleSolenoid m_#variable($Name){${Forward_PCM_Solenoid}, ${Forward_Channel_Solenoid}, ${Reverse_Channel_Solenoid}};"
     LiveWindow: "AddChild(\"$Short_Name\", &m_#variable($Name));"
 

--- a/src/main/resources/export/cpp/Subsystem-declarations.cpp
+++ b/src/main/resources/export/cpp/Subsystem-declarations.cpp
@@ -1,6 +1,8 @@
 #set($subsystem = $helper.getByName($subsystem_name, $robot))
 #foreach ($component in $components)
 #if ($component.subsystem == $subsystem.subsystem && $component != $subsystem)
+    #constructor($component)
+
     #livewindow($component)
 
     #extra($component)


### PR DESCRIPTION
Fixes #303
Revert changes to CustomComponent declaration to avoid breaking
extensions. Extensions that want to do initialization in the header like
the built-in objects can override the declaration field.
Restore export of construction field in subsystem. This is not used in
built-in objects but may be needed for extensions.