### PR TITLE
Fix parameter set validation

### DIFF
--- a/src/main/java/robotbuilder/ParameterSetsTable.java
+++ b/src/main/java/robotbuilder/ParameterSetsTable.java
@@ -210,17 +210,21 @@ class ParameterSetsTable extends JTable {
             case "String":
                 return !input.contains("\"") && !input.contains("\\");
             case "double":
-                return Utils.doesNotError(() -> Double.parseDouble((String) input));
+                if (".".equals(input) && existing.contains(".")) {
+                    // only allow one dot in a double
+                    return false;
+                }
+                if (offset == 0 && input.startsWith("-")) {
+                    return input.length() == 1 || input.substring(1).matches("[0-9]*\\.?[0-9]*");
+                }
+                return input.matches("[0-9]*\\.?[0-9]*");
             case "int":
-                return Utils.doesNotError(() -> Integer.parseInt((String) input));
             case "byte":
-                return (Utils.doesNotError(() -> Integer.parseInt((String) input))
-                        // use Integer.parseInt instead of Byte.parseByte because C++ maximum value is > Java's maximum value
-                        // and we have no way of knowing which language will be exported to
-                        && Integer.parseInt((String) input) >= -128 // -128 is minimum value in Java (C++: 0)
-                        && Integer.parseInt((String) input) < 256); // 255 is maximum value in C++ (Java: 127)
             case "long":
-                return Utils.doesNotError(() -> Long.parseLong((String) input));
+                if (offset == 0 && input.startsWith("-")) {
+                    return input.length() == 1 || input.substring(1).matches("[0-9]+");
+                }
+                return input.matches("[0-9]+");
             case "boolean":
                 return input.matches("false") || input.matches("true");
             default:


### PR DESCRIPTION
Reverts part of #294 because the parameter set validation occurs on a
character by character basis. The entire parameter is still validated
elsewhere, so it doesn't need to be done here.
Fixes #321