### PR TITLE
Revert "Disable compile tests until 2021 gradlerio is released (#347)"

### DIFF
--- a/src/test/java/robotbuilder/exporters/CppExportTest.java
+++ b/src/test/java/robotbuilder/exporters/CppExportTest.java
@@ -45,7 +45,6 @@ public class CppExportTest {
     public void tearDown() {
     }
 
-    @Ignore("Disabling compile test until GradleRIO 2021 version released")
     @Test
     public void testCPPExport() throws IOException, InterruptedException {
         RobotTree tree = TestUtils.generateTestTree();

--- a/src/test/java/robotbuilder/exporters/JavaExportTest.java
+++ b/src/test/java/robotbuilder/exporters/JavaExportTest.java
@@ -47,7 +47,6 @@ public class JavaExportTest {
     public void tearDown() {
     }
 
-    @Ignore("Disabling compile test until GradleRIO 2021 version released")
     @Test
     public void testJavaExport() throws IOException, InterruptedException {
         RobotTree tree = TestUtils.generateTestTree();


### PR DESCRIPTION
This reverts commit 96cf5f4710fccea2c5d15931013e13d79f415685.