### PR TITLE
Make subsystems public in RobotContainer

### DIFF
--- a/src/main/resources/export/cpp/RobotContainer-declarations.h
+++ b/src/main/resources/export/cpp/RobotContainer-declarations.h
@@ -1,12 +1,3 @@
-// The robot's subsystems
-#foreach ($component in $components)
-#if ("#type($component)" != "" 
-&& ("#type($component)" == "frc2::SubsystemBase"
-     || "#type($component)" == "frc2::PIDSubsystem"))
-    #class($component.getName()) #variable($component.getName());
-#end
-#end
-
 // Joysticks
 #foreach ($component in $components)
 #if ($helper.exportsTo("OI", $component)

--- a/src/main/resources/export/cpp/RobotContainer-prototypes.h
+++ b/src/main/resources/export/cpp/RobotContainer-prototypes.h
@@ -1,3 +1,12 @@
+// The robot's subsystems
+#foreach ($component in $components)
+#if ("#type($component)" != "" 
+&& ("#type($component)" == "frc2::SubsystemBase"
+     || "#type($component)" == "frc2::PIDSubsystem"))
+    #class($component.getName()) #variable($component.getName());
+#end
+#end
+
 ${Collections.reverse($components)}
 #foreach( $component in $components )
 #if ($helper.exportsTo("OI", $component) && "#prototype($component)" != "")

--- a/src/main/resources/export/java/RobotContainer-declarations.java
+++ b/src/main/resources/export/java/RobotContainer-declarations.java
@@ -4,7 +4,7 @@
 && "#type($component)" != "" 
 && ("#type($component)" == "SubsystemBase"
      || "#type($component)" == "PIDSubsystem"))
-    private final #class($component.getName()) m_#variable($component.getName()) = new #class($component.getName())();
+    public final #class($component.getName()) m_#variable($component.getName()) = new #class($component.getName())();
 #end
 #end
 


### PR DESCRIPTION
Allows commands that don't require the subystem to access them (Fixes #367), This also allows commands to require multiple subystems and avoids huge dependency chains for CommandGroups.