### PR TITLE
Revert "Disable compile tests until 2022 gradlerio is released (#434)"

### DIFF
--- a/src/test/java/robotbuilder/exporters/CppExportTest.java
+++ b/src/test/java/robotbuilder/exporters/CppExportTest.java
@@ -47,7 +47,6 @@ public class CppExportTest {
     public void tearDown() {
     }
 
-    @Ignore("Disabling compile test until GradleRIO 2022 version released")
     @Test
     public void testCPPExport() throws IOException, InterruptedException {
         RobotTree tree = TestUtils.generateTestTree();

--- a/src/test/java/robotbuilder/exporters/JavaExportTest.java
+++ b/src/test/java/robotbuilder/exporters/JavaExportTest.java
@@ -52,7 +52,6 @@ public class JavaExportTest {
         TestUtils.delete(project);
     }
 
-    @Ignore("Disabling compile test until GradleRIO 2022 version released")
     @Test
     public void testJavaExport() throws IOException, InterruptedException {
         RobotTree tree = TestUtils.generateTestTree();


### PR DESCRIPTION
This reverts commit 0ee917f88ea05bb0aa216649bc8004da3da067bf.