### PR TITLE
Warn User When No Team Number

### DIFF
--- a/src/main/java/robotbuilder/NewProjectDialog.java
+++ b/src/main/java/robotbuilder/NewProjectDialog.java
@@ -6,7 +6,11 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.util.Objects;
 
-import javax.swing.*;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JTextField;
+import javax.swing.JOptionPane;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.PlainDocument;

--- a/src/main/java/robotbuilder/NewProjectDialog.java
+++ b/src/main/java/robotbuilder/NewProjectDialog.java
@@ -4,11 +4,9 @@ package robotbuilder;
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.util.Objects;
 
-import javax.swing.JButton;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JTextField;
+import javax.swing.*;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.PlainDocument;
@@ -96,8 +94,15 @@ public class NewProjectDialog extends CenteredDialog {
 
         createButton = new JButton("Create Project");
         createButton.addActionListener(event -> {
-            MainFrame.getInstance().getCurrentRobotTree().newFile(nameField.getText(), teamField.getText());
-            setVisible(false);
+            if (!Objects.equals(teamField.getText(), "0")) {
+                MainFrame.getInstance().getCurrentRobotTree().newFile(nameField.getText(), teamField.getText());
+                setVisible(false);
+                System.out.println(teamField.getText().getClass());
+            } else {
+                JOptionPane.showMessageDialog(frame, "If you don't set a team number you will not be able to connect to your robot",
+                        "Swing Tester", JOptionPane.WARNING_MESSAGE);
+            }
+
         });
         c.gridx = 1;
         c.gridy = 3;


### PR DESCRIPTION
Hi!

It's been a constant issue on my team that people create robot builder projects without a team number and then we spend hours trying to figure out why it won't connect to the roboRIO, just to realize that the project is missing a team number. Anyone using this software will be on a FIRST robotics team with a number, so there's no reason they can't enter one. Therefore I want to add a warning to ensure projects have a team number. Also, I know that there should only be one commit, however, I realized there was a mistake in the first commit and wasn't sure how to drop it and only use the second.