### PR TITLE
Revert "Disable compile tests until 2023 gradlerio is released (#536)"

### DIFF
--- a/src/test/java/robotbuilder/exporters/CppExportTest.java
+++ b/src/test/java/robotbuilder/exporters/CppExportTest.java
@@ -50,7 +50,6 @@ public class CppExportTest {
         TestUtils.delete(project);
     }
 
-    @Ignore("Disabling compile test until GradleRIO 2023 version released")
     @Test
     public void testCPPExport() throws IOException, InterruptedException {
         RobotTree tree = TestUtils.generateTestTree();

--- a/src/test/java/robotbuilder/exporters/JavaExportTest.java
+++ b/src/test/java/robotbuilder/exporters/JavaExportTest.java
@@ -52,7 +52,6 @@ public class JavaExportTest {
         TestUtils.delete(project);
     }
 
-    @Ignore("Disabling compile test until GradleRIO 2023 version released")
     @Test
     public void testJavaExport() throws IOException, InterruptedException {
         RobotTree tree = TestUtils.generateTestTree();


### PR DESCRIPTION
This reverts commit af1e91acea1009887f865de38126460f1aa1166e.