### PR TITLE
Workaround for gradle rebuilding headers in C++ user projects

### DIFF
--- a/src/main/resources/export/gradle/settings.gradle
+++ b/src/main/resources/export/gradle/settings.gradle
@@ -25,3 +25,6 @@ pluginManagement {
         }
     }
 }
+
+Properties props = System.getProperties();
+props.setProperty("org.gradle.internal.native.headers.unresolved.dependencies.ignore", "true");


### PR DESCRIPTION
Matches wpilibsuite/vscode-wpilib#617