### PR TITLE
Disable compile tests and don't use development builds

### DIFF
--- a/src/main/resources/export/cpp/build.gradle
+++ b/src/main/resources/export/cpp/build.gradle
@@ -4,11 +4,6 @@ plugins {
     id "edu.wpi.first.GradleRIO" version "${wpilib_version}"
 }
 
-wpi.maven.useLocal = false
-wpi.maven.useDevelopment = true
-wpi.versions.wpilibVersion = '2024.+'
-wpi.versions.wpimathVersion = '2024.+'
-
 // Define my targets (RoboRIO) and artifacts (deployable files)
 // This is added by GradleRIO's backing project DeployTools.
 deploy {

--- a/src/main/resources/export/java/build.gradle
+++ b/src/main/resources/export/java/build.gradle
@@ -5,11 +5,6 @@ plugins {
     id "edu.wpi.first.GradleRIO" version "${wpilib_version}"
 }
 
-wpi.maven.useLocal = false
-wpi.maven.useDevelopment = true
-wpi.versions.wpilibVersion = '2024.+'
-wpi.versions.wpimathVersion = '2024.+'
-
 java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17

--- a/src/test/java/robotbuilder/exporters/CppExportTest.java
+++ b/src/test/java/robotbuilder/exporters/CppExportTest.java
@@ -50,6 +50,7 @@ public class CppExportTest {
         TestUtils.delete(project);
     }
 
+    @Ignore("Disabling compile test until GradleRIO 2024 version released")
     @Test
     public void testCPPExport() throws IOException, InterruptedException {
         RobotTree tree = TestUtils.generateTestTree();

--- a/src/test/java/robotbuilder/exporters/JavaExportTest.java
+++ b/src/test/java/robotbuilder/exporters/JavaExportTest.java
@@ -52,6 +52,7 @@ public class JavaExportTest {
         TestUtils.delete(project);
     }
 
+    @Ignore("Disabling compile test until GradleRIO 2023 version released")
     @Test
     public void testJavaExport() throws IOException, InterruptedException {
         RobotTree tree = TestUtils.generateTestTree();


### PR DESCRIPTION
Disable compile tests because c++ is broken until the next gradlerio release
Since compile tests are disabled, revert using development builds since they won't be needed when the next gradlerio is released.
Should be rebase merged so that compile test commit can be reverted.