### PR TITLE
Revert "Disable compile tests until 2024 GradleRIO released (#588) (#…

### DIFF
--- a/src/test/java/robotbuilder/exporters/CppExportTest.java
+++ b/src/test/java/robotbuilder/exporters/CppExportTest.java
@@ -50,7 +50,6 @@ public class CppExportTest {
         TestUtils.delete(project);
     }
 
-    @Ignore("Disabling compile test until GradleRIO 2024 version released")
     @Test
     public void testCPPExport() throws IOException, InterruptedException {
         RobotTree tree = TestUtils.generateTestTree();

--- a/src/test/java/robotbuilder/exporters/JavaExportTest.java
+++ b/src/test/java/robotbuilder/exporters/JavaExportTest.java
@@ -52,7 +52,6 @@ public class JavaExportTest {
         TestUtils.delete(project);
     }
 
-    @Ignore("Disabling compile test until GradleRIO 2024 version released")
     @Test
     public void testJavaExport() throws IOException, InterruptedException {
         RobotTree tree = TestUtils.generateTestTree();


### PR DESCRIPTION
…594)"

This reverts commit 4f0fade75a504ce81cdd54fec8586fe2ae339add.