### PR TITLE
Revert "Add case sensitive file support to C++ projects (#620)"

### DIFF
--- a/src/main/resources/export/cpp/settings.json
+++ b/src/main/resources/export/cpp/settings.json
@@ -14,6 +14,5 @@
     "**/.factorypath": true,
     "**/*~": true
   },
-  "C_Cpp.default.configurationProvider": "vscode-wpilib",
-  "C_Cpp.caseSensitiveFileSupport": "enabled",
+  "C_Cpp.default.configurationProvider": "vscode-wpilib"
 }


### PR DESCRIPTION
Fixed in CPP extension 1.22.9

This reverts commit c2143e57488bfdd81bec108ae1f92f6128d37c5b.